### PR TITLE
nvim: support run lsp inside container

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -19,6 +19,14 @@ IS_MAC=false
 IS_LINUX=false
 [[ $(uname -s) == "Darwin" ]] && IS_MAC=true || IS_LINUX=true
 
+# ── CONTAINER COMMAND ────────────────────────────────────────────────────────
+# Used by Neovim to run LSP servers inside containers (see lsp_container.md)
+if $IS_MAC; then
+  export CONTAINER_COMMAND="docker"
+else
+  export CONTAINER_COMMAND="podman"
+fi
+
 # ── HISTORY & OPTIONS ────────────────────────────────────────────────────────
 export HISTFILE="$HOME/.zsh_history"
 export HISTSIZE=32768

--- a/.zshrc
+++ b/.zshrc
@@ -20,9 +20,8 @@ IS_LINUX=false
 [[ $(uname -s) == "Darwin" ]] && IS_MAC=true || IS_LINUX=true
 
 # ── CONTAINER COMMAND ────────────────────────────────────────────────────────
-# Used by Neovim to run LSP servers inside containers (see lsp_container.md)
 if $IS_MAC; then
-  export CONTAINER_COMMAND="docker"
+  export CONTAINER_COMMAND="container"
 else
   export CONTAINER_COMMAND="podman"
 fi

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -530,6 +530,36 @@ ec_prop("enable_lsp",            "true")
 ec_prop("exclude_ignorefiles",   "true")
 ec_prop("exclude_hidden",        "true")
 ec_prop("exclude_files",         "")
+ec_prop("container_name",        "")
+
+-- ── CONTAINER LSP ─────────────────────────────────────────────────────────────
+local function lsp_cmd(server, cmd, bufnr)
+  local ec = vim.b[bufnr].editorconfig or {}
+  local name = ec.container_name
+  if not name or name == "" then return cmd end
+
+  local container_cmd = vim.env.CONTAINER_COMMAND
+  if not container_cmd or container_cmd == "" or vim.fn.executable(container_cmd) ~= 1 then
+    vim.notify(
+      ("[LSP] %q not found — %s runs locally"):format(container_cmd, server),
+      vim.log.levels.WARN
+    )
+    return cmd
+  end
+
+  local check = vim.system({ container_cmd, "inspect", "-f", "{{.State.Running}}", name }, { text = true }):wait()
+  if check.code ~= 0 or vim.trim(check.stdout or "") ~= "true" then
+    vim.notify(
+      ("[LSP] container %q not running — %s runs locally"):format(name, server),
+      vim.log.levels.WARN
+    )
+    return cmd
+  end
+
+  local wrapped = { container_cmd, "exec", "-i", name }
+  for _, arg in ipairs(cmd) do table.insert(wrapped, arg) end
+  return wrapped
+end
 
 -- ── LANGUAGE SETTINGS ─────────────────────────────────────────────────────────
 
@@ -552,32 +582,49 @@ local function set_rg(ft, flags)
   end, { buffer = 0, desc = "Search selection to quickfix (scoped)" })
 end
 
+local function enable_lsp(server, bufnr)
+  local cfg = vim.lsp.config[server] or {}
+  local base_cmd = cfg.cmd
+  if not base_cmd then
+    vim.lsp.enable(server)
+    return
+  end
+  local cmd = lsp_cmd(server, base_cmd, bufnr)
+  if not cmd then return end
+  local override = { cmd = cmd }
+  if cmd ~= base_cmd then
+    override.before_init = function(params) params.processId = vim.NIL end
+  end
+  vim.lsp.config(server, override)
+  vim.lsp.enable(server)
+end
+
 local ft = {}
 
-ft.c = function()
-  set_rg("c/cpp", { "--type", "c", "--type", "cpp", "-g", "!thrift", "-g", "!thriftzg" })
-  vim.lsp.enable("clangd")
+ft.c = function(ev)
+  set_rg("c/cpp", { "--type", "c", "--type", "cpp"})
+  enable_lsp("clangd", ev.buf)
 end
 ft.cpp = ft.c
 
 ft.java = function()
-  set_rg("java", {"--type", "java", "-g", "!thrift", "-g", "!thriftzg"})
+  set_rg("java", {"--type", "java"})
 end
 
-ft.rust = function()
-  vim.lsp.enable("rust-analyzer")
+ft.rust = function(ev)
+  enable_lsp("rust_analyzer", ev.buf)
 end
 
-ft.go = function()
-  vim.lsp.enable("gopls")
+ft.go = function(ev)
+  enable_lsp("gopls", ev.buf)
 end
 
-ft.python = function()
-  vim.lsp.enable("pyright")
+ft.python = function(ev)
+  enable_lsp("pyright", ev.buf)
 end
 
-ft.lua = function()
-  vim.lsp.enable("lua_ls")
+ft.lua = function(ev)
+  enable_lsp("lua_ls", ev.buf)
 end
 
 vim.api.nvim_create_autocmd("FileType", {
@@ -591,4 +638,3 @@ vim.api.nvim_create_autocmd("FileType", {
     end)
   end
 })
-

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -471,7 +471,6 @@ vim.keymap.set("v", "gw", function()
 end, { desc = "Search selection to quickfix" })
 
 vim.api.nvim_create_user_command("Rg", function(opts) rg_qf(opts.args, {}) end, { nargs="+" })
-vim.cmd("cabbrev rg Rg")
 
 -- ── KEYMAPS ───────────────────────────────────────────────────────────────────
 vim.keymap.set("n", "<leader>yf", function() vim.fn.setreg("+", vim.fn.expand("%:p")) end, { desc="Yank path" })


### PR DESCRIPTION
Run LSP servers inside a container while Neovim runs on the host.
No plugins required — uses native `vim.lsp` (Neovim 0.12.2).

## Architecture

```
┌─── Host ────────────────────────────────────────────────┐
│  Neovim  ←── stdio (JSON-RPC) ──→  $CONTAINER_COMMAND  │
│                                     exec -i <name>      │
│                                       │                 │
│  ~/code/project ──── bind mount ──────┼──────────┐      │
│                                       │          │      │
│  ┌─── Container ──────────────────────▼──────────▼──┐   │
│  │  LSP server (clangd, pyright, …)                 │   │
│  │  sees ~/code/project at same absolute path       │   │
│  └──────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────┘
```

## Important Constraints

### Do NOT use `-t` (tty)
`exec -i` only. The `-t` flag allocates a pseudo-TTY which corrupts the binary
JSON-RPC stream between Neovim and the LSP server.

### Same-path bind mount is mandatory
If host path ≠ container path, every URI in every LSP response would need translation.
Same-path mounting eliminates this entirely — zero complexity, zero bugs.

### PID namespace mismatch (handled automatically)
The LSP `initialize` request includes `processId` so the server can monitor if the
client is alive. A containerized server can't see host PIDs — it would think the client
died and exit immediately. `enable_lsp()` handles this by injecting
`before_init` to set `processId = vim.NIL` (JSON `null`) when in container mode.

### File watching is limited
Containers don't receive host filesystem events (inotify). LSP features relying on
`workspace/didChangeWatchedFiles` won't auto-trigger. This is acceptable because:
- `textDocument/didOpen` and `textDocument/didChange` still work (Neovim sends these)
- Manual save triggers re-analysis
- Most LSP features (completion, diagnostics, go-to-def) are unaffected

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| `[LSP] container "x" not running` | Container stopped or name typo | `docker start x` or fix `.editorconfig` |
| LSP starts but can't find files | Path mismatch in bind mount | Use same absolute path: `-v $HOME/code:$HOME/code` |
| LSP exits immediately | PID namespace mismatch | Handled by `before_init` — check `enable_lsp()` is used |
| Garbled LSP output | Used `-t` flag | Use `exec -i` only, never `-it` |
| No `$CONTAINER_COMMAND` | Shell not sourced | Restart terminal or `source ~/.zshrc` |
| LSP falls back to local silently | Container not running | Expected behaviour — check `:messages` for warning |
