### PR TITLE
nvim(lsp): support jump into file inside container

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -555,45 +555,19 @@ local function sync_container_file(name, path)
   return cache_path
 end
 
-local function fix_location(loc, container_name)
-  local uri = loc.uri or loc.targetUri
-  if not uri or not uri:match("^file://") then return end
+local orig_uri_to_fname = vim.uri_to_fname
+vim.uri_to_fname = function(uri)
+  local path = orig_uri_to_fname(uri)
+  if not uri:match("^file://") then return path end
 
-  local path = vim.uri_to_fname(uri)
-  if vim.fn.filereadable(path) == 1 then return end
+  local buf = vim.api.nvim_get_current_buf()
+  local name = vim.b[buf].editorconfig and vim.b[buf].editorconfig.container_name
+  if not name or name == "" then return path end
 
-  local cached_file = sync_container_file(container_name, path)
-  if not cached_file then return end
+  local cwd = vim.fn.getcwd()
+  if path == cwd or vim.startswith(path, cwd .. "/") then return path end
 
-  local new_uri = vim.uri_from_fname(cached_file)
-  if loc.uri then loc.uri = new_uri end
-  if loc.targetUri then loc.targetUri = new_uri end
-end
-
-local orig_locations_to_items = vim.lsp.util.locations_to_items
-vim.lsp.util.locations_to_items = function(locations, offset_encoding)
-  local name = vim.b.editorconfig and vim.b.editorconfig.container_name
-  if not name or name == "" then
-    return orig_locations_to_items(locations, offset_encoding)
-  end
-
-  for _, loc in ipairs(locations) do
-    fix_location(loc, name)
-  end
-  return orig_locations_to_items(locations, offset_encoding)
-end
-
-local orig_show_document = vim.lsp.util.show_document
-if orig_show_document then
-  vim.lsp.util.show_document = function(location, position_encoding, opts)
-    local name = vim.b.editorconfig and vim.b.editorconfig.container_name
-    if not name or name == "" then
-      return orig_show_document(location, position_encoding, opts)
-    end
-
-    fix_location(location, name)
-    return orig_show_document(location, position_encoding, opts)
-  end
+  return sync_container_file(name, path) or path
 end
 
 -- ── CONTAINER LSP ─────────────────────────────────────────────────────────────

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -531,27 +531,77 @@ ec_prop("exclude_hidden",        "true")
 ec_prop("exclude_files",         "")
 ec_prop("container_name",        "")
 
--- ── CONTAINER LSP ─────────────────────────────────────────────────────────────
-local function lsp_cmd(server, cmd, bufnr)
-  local ec = vim.b[bufnr].editorconfig or {}
-  local name = ec.container_name
-  if not name or name == "" then return cmd end
-
+-- ── CONTAINER LSP FILE CACHE ─────────────────────────────────────────────────
+-- Intercepts LSP jumps to remote files and locally caches them in $PWD/.cache/
+local function sync_container_file(name, path)
   local container_cmd = vim.env.CONTAINER_COMMAND
-  if not container_cmd or container_cmd == "" or vim.fn.executable(container_cmd) ~= 1 then
-    vim.notify(
-      ("[LSP] %q not found — %s runs locally"):format(container_cmd, server),
-      vim.log.levels.WARN
-    )
-    return cmd
+  if not container_cmd or container_cmd == "" then return nil end
+
+  local cache_path = vim.fn.getcwd() .. "/.cache/container_nfm/" .. name .. path
+  if vim.fn.filereadable(cache_path) == 1 then return cache_path end
+
+  local res = vim.system({ container_cmd, "exec", "-i", name, "cat", path }, { text = true }):wait()
+  if res.code ~= 0 then return nil end
+
+  local lines = {}
+  if res.stdout and res.stdout ~= "" then
+    lines = vim.split(res.stdout, "\n")
+    if #lines > 0 and lines[#lines] == "" then
+      table.remove(lines)
+    end
+  end
+  vim.fn.mkdir(vim.fn.fnamemodify(cache_path, ":h"), "p")
+  vim.fn.writefile(lines, cache_path)
+  return cache_path
+end
+
+local function fix_location(loc, container_name)
+  local uri = loc.uri or loc.targetUri
+  if not uri or not uri:match("^file://") then return end
+
+  local path = vim.uri_to_fname(uri)
+  if vim.fn.filereadable(path) == 1 then return end
+
+  local cached_file = sync_container_file(container_name, path)
+  if not cached_file then return end
+
+  local new_uri = vim.uri_from_fname(cached_file)
+  if loc.uri then loc.uri = new_uri end
+  if loc.targetUri then loc.targetUri = new_uri end
+end
+
+local orig_locations_to_items = vim.lsp.util.locations_to_items
+vim.lsp.util.locations_to_items = function(locations, offset_encoding)
+  local name = vim.b.editorconfig and vim.b.editorconfig.container_name
+  if not name or name == "" then
+    return orig_locations_to_items(locations, offset_encoding)
   end
 
-  local check = vim.system({ container_cmd, "inspect", "-f", "{{.State.Running}}", name }, { text = true }):wait()
-  if check.code ~= 0 or vim.trim(check.stdout or "") ~= "true" then
-    vim.notify(
-      ("[LSP] container %q not running — %s runs locally"):format(name, server),
-      vim.log.levels.WARN
-    )
+  for _, loc in ipairs(locations) do
+    fix_location(loc, name)
+  end
+  return orig_locations_to_items(locations, offset_encoding)
+end
+
+local orig_show_document = vim.lsp.util.show_document
+if orig_show_document then
+  vim.lsp.util.show_document = function(location, position_encoding, opts)
+    local name = vim.b.editorconfig and vim.b.editorconfig.container_name
+    if not name or name == "" then
+      return orig_show_document(location, position_encoding, opts)
+    end
+
+    fix_location(location, name)
+    return orig_show_document(location, position_encoding, opts)
+  end
+end
+
+-- ── CONTAINER LSP ─────────────────────────────────────────────────────────────
+local function lsp_cmd(server, cmd, bufnr)
+  local name = (vim.b[bufnr].editorconfig or {}).container_name
+  local container_cmd = vim.env.CONTAINER_COMMAND
+
+  if not name or name == "" or not container_cmd or container_cmd == "" then
     return cmd
   end
 
@@ -631,6 +681,7 @@ vim.api.nvim_create_autocmd("FileType", {
   callback = function(ev)
     vim.schedule(function()
       if not vim.api.nvim_buf_is_valid(ev.buf) then return end
+      if not vim.uri_from_bufnr(ev.buf):match("^file://") then return end
       local b = vim.b[ev.buf]
       if b.editorconfig and b.editorconfig.enable_lsp == "false" then return end
       if ft[ev.match] then ft[ev.match](ev) end

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -537,7 +537,7 @@ local function sync_container_file(name, path)
   local container_cmd = vim.env.CONTAINER_COMMAND
   if not container_cmd or container_cmd == "" then return nil end
 
-  local cache_path = vim.fn.getcwd() .. "/.cache/container_nfm/" .. name .. path
+  local cache_path = vim.fn.getcwd() .. "/.cache/container/" .. name .. path
   if vim.fn.filereadable(cache_path) == 1 then return cache_path end
 
   local res = vim.system({ container_cmd, "exec", "-i", name, "cat", path }, { text = true }):wait()


### PR DESCRIPTION
  ## 📝 Description

  This PR overhauls the container LSP integration by stripping out the complex virtual  container://  scheme and replacing it with a native caching approach. It
  eliminates deep nesting, removes redundant execution checks, and fixes a persistent  clangd  crash associated with Fugitive virtual buffers.

  ## 🏗️ Architectural Flow

  The new flow bypasses virtual buffers completely. It intercepts the jump request, seamlessly downloads the file via a fast-failing subprocess, and rewrites the
  jump
  destination to the local cache.

       [ LSP Jump Request ]
                |
                v
         [ Interceptor ] ------------> (No $CONTAINER_COMMAND)
                |                               |
                v                               |
      (Not in $PWD/.cache)                      |
                |                               |
                v                               |
        [ $CONTAINER_COMMAND exec cat ] ----(Fails)----> [ Local Jump ]
                |
            (Success)
                |
                v
         [ Write to Cache ]
                |
                v
        [ Rewrite Jump URI ]
                |
                v
       [ Open Native Buffer ]

  ## ✨ Key Changes

  • Native Caching:
      • Removed the  BufReadCmd  overhead. We now intercept  locations_to_items  to fetch files natively into  `$PWD/.cache/container/`  and rewrite the URI to
      `file://` .
      • Fixes: Resolves the  Invalid cursor line  exception that Neovim 0.12 threw on virtual buffers.
  • Fast-Failing Execution:
      • Removed synchronous  `docker inspect`  and  `vim.fn.executable`  pre-checks. We now rely strictly on  `vim.system()` 's native exit codes. If the container is down,
      it fails instantly.
  • Fugitive LSP Bug Fix:
      • Added a strict  `vim.uri_from_bufnr(ev.buf):match("^file://")`  guard. LSP clients will no longer crash trying to attach to  `fugitive://`  or  `oil://`  scratch
      buffers.


